### PR TITLE
feat(db): add Review model to db

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,6 +3,7 @@ class Item < ApplicationRecord
 
   validates :name, presence: true
   validates :price, numericality: { greater_than_or_equal_to: 0 }
+  has_many :reviews, dependent: :destroy
 end
 
 # == Schema Information

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,0 +1,27 @@
+class Review < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+end
+
+# == Schema Information
+#
+# Table name: reviews
+#
+#  id         :bigint(8)        not null, primary key
+#  user_id    :bigint(8)        not null
+#  item_id    :bigint(8)        not null
+#  body       :string
+#  rating     :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_reviews_on_item_id  (item_id)
+#  index_reviews_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (item_id => items.id)
+#  fk_rails_...  (user_id => users.id)
+#

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :purchases, dependent: :destroy
+  has_many :reviews, dependent: :destroy
 end
 
 # == Schema Information

--- a/db/migrate/20221226202733_create_reviews.rb
+++ b/db/migrate/20221226202733_create_reviews.rb
@@ -1,0 +1,12 @@
+class CreateReviews < ActiveRecord::Migration[6.1]
+  def change
+    create_table :reviews do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :item, null: false, foreign_key: true
+      t.string :body
+      t.integer :rating
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_15_145239) do
+ActiveRecord::Schema.define(version: 2022_12_26_202733) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -63,6 +63,17 @@ ActiveRecord::Schema.define(version: 2022_12_15_145239) do
     t.index ["user_id"], name: "index_purchases_on_user_id"
   end
 
+  create_table "reviews", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.string "body"
+    t.integer "rating"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_id"], name: "index_reviews_on_item_id"
+    t.index ["user_id"], name: "index_reviews_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -77,4 +88,6 @@ ActiveRecord::Schema.define(version: 2022_12_15_145239) do
 
   add_foreign_key "purchases", "items"
   add_foreign_key "purchases", "users"
+  add_foreign_key "reviews", "items"
+  add_foreign_key "reviews", "users"
 end

--- a/spec/factories/reviews.rb
+++ b/spec/factories/reviews.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :review do
+    user
+    item
+    body { "MyString" }
+    rating { 1 }
+  end
+end

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe Review, type: :model do
+  context 'with valid attributes' do
+    it { expect(build(:review)).to be_valid }
+  end
+end


### PR DESCRIPTION
### Contexto

El problema es el siguiente: se necesita crear un nuevo modelo Review, que relaciona un usuario con un producto. Con los siguientes atributos:
- user_id
- item_id
- body

[Ver enunciado](https://www.notion.so/platanus/Agregar-reviews-a-los-productos-e55e8851b1a342b7a1b65dbffd8b91fa)

### Qué se esta haciendo

Al inicio se corrieron las migraciones pendientes con `bin/rails db:schema:load`. Posteriormente para crear el modelo se uso el comando `bin/rails generate model Review users:references items:references body:string`. Se corrieron las migraciones con `db:migrate` y se checkearon si estaban todas bien con `db:migrate:status`.

#### En particular hay que revisar

Si la creacion del modelo fue correcta y con tiene los atributos necesarios.

