### PR TITLE
feat(active-admin): add activeadmin for Review

### DIFF
--- a/app/admin/reviews.rb
+++ b/app/admin/reviews.rb
@@ -1,0 +1,22 @@
+ActiveAdmin.register Review do
+  permit_params :body, :rating
+
+  includes :item, :user
+
+  index do
+    selectable_column
+    id_column
+    column :item
+    column :user
+    column :rating
+    actions
+  end
+
+  form do |f|
+    f.inputs do
+      f.input :body
+      f.input :rating
+    end
+    f.actions
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,3 +31,4 @@
 
 en:
   hello: "Hello world"
+

--- a/config/locales/es-CL.yml
+++ b/config/locales/es-CL.yml
@@ -1,2 +1,21 @@
 es-CL:
   hello: "Hola mundo"
+  activerecord:
+    models:
+      review:
+        one: Reseña
+        other: Reseñas
+      user:
+        one: Usuario
+        other: Usuarios
+      purchase:
+        one: Compra
+        other: Compras
+    attributes:
+      review:
+        item: Item
+        user: Usuario
+        body: Descripción
+  attributes:
+    created_at: Fecha de creación
+    updated_at: Fecha de actualización


### PR DESCRIPTION
### Contexto
Agregar páginas de ActiveAdmin del nuevo modelo Review : index, show y form. En el index no mostrar el body

[Ver enunciado](https://www.notion.so/platanus/Agregar-reviews-a-los-productos-e55e8851b1a342b7a1b65dbffd8b91fa)

### Qué se esta haciendo

Se creo una vista de active admin en `/app/admin/reviews.rb`, tomando en cuenta que en el index no se muestra el body. `includes` al item y user para que se pueda ver mejor las relaciones.


#### En particular hay que revisar

Si está bien definido Active Admin de Reviews.

-----------
#### Info Adicional (pantallazos, links, fuentes, etc.)
![image](https://user-images.githubusercontent.com/38754555/209678293-6cb79ab6-8bf2-47ae-b8a2-fecd0cd597d4.png)

